### PR TITLE
feat: wire export destinations into AI and Visual job creation

### DIFF
--- a/frontend/app/(application)/dashboard/jobs/new/ai/page.tsx
+++ b/frontend/app/(application)/dashboard/jobs/new/ai/page.tsx
@@ -19,6 +19,8 @@ import {
   Pencil,
 } from 'lucide-react';
 import { jobsAPI, type AISuggestResponse } from '@/lib/api/jobs';
+import { buildAiJobPayload } from '@/lib/jobs/buildAiJobPayload';
+import { DestinationSelector } from '@/components/destinations/DestinationSelector';
 import { toast } from '@/lib/toast';
 
 type Step = 'describe' | 'review' | 'configure';
@@ -46,6 +48,7 @@ export default function AIJobCreationPage() {
   // Configure step
   const [jobName, setJobName] = useState('');
   const [rateLimit, setRateLimit] = useState(2);
+  const [destinationIds, setDestinationIds] = useState<string[]>([]);
 
   const handleAnalyze = async () => {
     if (!url || !description) {
@@ -93,22 +96,14 @@ export default function AIJobCreationPage() {
       const token = await getToken();
       if (!token) throw new Error('Not authenticated');
 
-      const queries = acceptedFields.map((field) => ({
-        name: field.name,
-        type: field.useAi ? ('ai' as const) : (field.type === 'css' ? 'xpath' as const : field.type as 'xpath' | 'regex' | 'ai'),
-        query: field.useAi ? field.description : field.query,
-        join: false,
-      }));
-
       await jobsAPI.create(
-        {
+        buildAiJobPayload({
           name: jobName,
-          source: url,
-          source_type: 'direct_url',
-          url_template: url,
-          rate_limit: rateLimit,
-          queries,
-        } as any,
+          url,
+          rateLimit,
+          fields: suggestions,
+          destinationIds,
+        }),
         token
       );
 
@@ -333,6 +328,14 @@ export default function AIJobCreationPage() {
                   value={rateLimit}
                   onChange={(e) => setRateLimit(Number(e.target.value))}
                 />
+              </div>
+
+              <div className="space-y-2">
+                <Label>Export Destinations (optional)</Label>
+                <p className="text-xs text-muted-foreground">
+                  Pick saved destinations to auto-export results to Google Docs after each successful run.
+                </p>
+                <DestinationSelector value={destinationIds} onChange={setDestinationIds} />
               </div>
 
               <div className="bg-muted/50 rounded-lg p-4 space-y-2">

--- a/frontend/app/(application)/dashboard/jobs/new/visual/page.tsx
+++ b/frontend/app/(application)/dashboard/jobs/new/visual/page.tsx
@@ -35,6 +35,7 @@ import {
 } from 'lucide-react';
 import { toast } from '@/lib/toast';
 import { jobsAPI } from '@/lib/api';
+import { DestinationSelector } from '@/components/destinations/DestinationSelector';
 import { useWebSocket } from '@/lib/useWebSocket';
 
 interface ExtractedField {
@@ -58,6 +59,7 @@ export default function VisualBuilderPage() {
   const [pageStructure, setPageStructure] = useState<any>(null);
   const [isTesting, setIsTesting] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [destinationIds, setDestinationIds] = useState<string[]>([]);
 
   // Async scraper state
   const [asyncTaskId, setAsyncTaskId] = useState<string | null>(null);
@@ -375,6 +377,7 @@ export default function VisualBuilderPage() {
           source: targetUrl,
           queries,
           rate_limit: 10, // Default rate limit
+          export_destination_ids: destinationIds,
         },
         token
       );
@@ -751,7 +754,14 @@ export default function VisualBuilderPage() {
         {/* Save Actions */}
         {pageLoaded && extractedFields.length > 0 && (
           <Card className="border-accent">
-            <CardContent className="pt-6">
+            <CardContent className="pt-6 space-y-4">
+              <div className="space-y-2">
+                <Label>Export Destinations (optional)</Label>
+                <p className="text-sm text-muted-foreground">
+                  Pick saved destinations to auto-export results to Google Docs after each successful run.
+                </p>
+                <DestinationSelector value={destinationIds} onChange={setDestinationIds} />
+              </div>
               <div className="flex items-center justify-between">
                 <div>
                   <h3 className="text-lg font-semibold mb-1">Save Your Configuration</h3>

--- a/frontend/lib/__tests__/buildAiJobPayload.test.ts
+++ b/frontend/lib/__tests__/buildAiJobPayload.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { buildAiJobPayload, type AiSuggestionField } from '@/lib/jobs/buildAiJobPayload';
+
+const field = (over: Partial<AiSuggestionField> = {}): AiSuggestionField => ({
+  name: 'price',
+  type: 'xpath',
+  query: '//span[@class="price"]',
+  description: 'the product price',
+  accepted: true,
+  useAi: false,
+  ...over,
+});
+
+describe('buildAiJobPayload', () => {
+  it('includes only accepted fields as queries', () => {
+    const payload = buildAiJobPayload({
+      name: 'Test',
+      url: 'https://example.com',
+      rateLimit: 2,
+      fields: [
+        field({ name: 'price' }),
+        field({ name: 'sku', accepted: false }),
+      ],
+      destinationIds: [],
+    });
+
+    expect(payload.queries).toHaveLength(1);
+    expect(payload.queries[0].name).toBe('price');
+  });
+
+  it('passes export_destination_ids through to the payload', () => {
+    const payload = buildAiJobPayload({
+      name: 'Test',
+      url: 'https://example.com',
+      rateLimit: 2,
+      fields: [field()],
+      destinationIds: ['d-1', 'd-2'],
+    });
+
+    expect(payload.export_destination_ids).toEqual(['d-1', 'd-2']);
+  });
+
+  it('defaults export_destination_ids to an empty array', () => {
+    const payload = buildAiJobPayload({
+      name: 'Test',
+      url: 'https://example.com',
+      rateLimit: 2,
+      fields: [field()],
+      destinationIds: [],
+    });
+
+    expect(payload.export_destination_ids).toEqual([]);
+  });
+
+  it('uses the description as the query and ai type when useAi is set', () => {
+    const payload = buildAiJobPayload({
+      name: 'Test',
+      url: 'https://example.com',
+      rateLimit: 2,
+      fields: [field({ useAi: true, description: 'extract the price', query: '//ignored' })],
+      destinationIds: [],
+    });
+
+    expect(payload.queries[0].type).toBe('ai');
+    expect(payload.queries[0].query).toBe('extract the price');
+  });
+
+  it('downgrades css selectors to xpath (AI suggest returns css but backend job runs xpath)', () => {
+    const payload = buildAiJobPayload({
+      name: 'Test',
+      url: 'https://example.com',
+      rateLimit: 2,
+      fields: [field({ type: 'css', useAi: false })],
+      destinationIds: [],
+    });
+
+    expect(payload.queries[0].type).toBe('xpath');
+  });
+
+  it('sets source, source_type and url_template from the url', () => {
+    const payload = buildAiJobPayload({
+      name: 'My Job',
+      url: 'https://example.com/products',
+      rateLimit: 3,
+      fields: [field()],
+      destinationIds: [],
+    });
+
+    expect(payload.name).toBe('My Job');
+    expect(payload.source).toBe('https://example.com/products');
+    expect(payload.source_type).toBe('direct_url');
+    expect(payload.url_template).toBe('https://example.com/products');
+    expect(payload.rate_limit).toBe(3);
+  });
+});

--- a/frontend/lib/api/jobs.ts
+++ b/frontend/lib/api/jobs.ts
@@ -9,7 +9,10 @@ import { Job } from '@/lib/types';
 export interface CreateJobDTO {
   name: string;
   source: string;
+  source_type?: string;
+  url_template?: string;
   rate_limit?: number;
+  export_destination_ids?: string[];
   queries: Array<{
     name: string;
     type: string;

--- a/frontend/lib/jobs/buildAiJobPayload.ts
+++ b/frontend/lib/jobs/buildAiJobPayload.ts
@@ -1,0 +1,54 @@
+/**
+ * buildAiJobPayload
+ * Pure helper that turns the AI-assisted creation wizard's state into a
+ * CreateJobDTO. Extracted so the payload shape (including export destinations)
+ * is unit-testable independently of the React page.
+ */
+
+import type { CreateJobDTO } from '@/lib/api/jobs';
+
+export interface AiSuggestionField {
+  name: string;
+  type: 'xpath' | 'css' | 'regex' | 'ai';
+  query: string;
+  description: string;
+  accepted: boolean;
+  useAi: boolean;
+}
+
+interface BuildAiJobPayloadParams {
+  name: string;
+  url: string;
+  rateLimit: number;
+  fields: AiSuggestionField[];
+  destinationIds: string[];
+}
+
+export function buildAiJobPayload({
+  name,
+  url,
+  rateLimit,
+  fields,
+  destinationIds,
+}: BuildAiJobPayloadParams): CreateJobDTO {
+  const queries = fields
+    .filter((f) => f.accepted)
+    .map((field) => ({
+      name: field.name,
+      // The backend job runner supports xpath/regex/ai, not raw css, so a css
+      // suggestion is downgraded to xpath unless the user flipped it to AI.
+      type: field.useAi ? 'ai' : field.type === 'css' ? 'xpath' : field.type,
+      query: field.useAi ? field.description : field.query,
+      join: false,
+    }));
+
+  return {
+    name,
+    source: url,
+    source_type: 'direct_url',
+    url_template: url,
+    rate_limit: rateLimit,
+    queries,
+    export_destination_ids: destinationIds,
+  };
+}


### PR DESCRIPTION
## What

Wires the Google Docs export-destination selector into the two job-creation flows that were missing it. Previously only the **manual** job form rendered `DestinationSelector`; the **AI-assisted** and **Visual builder** flows silently dropped any chosen destinations, so jobs created there could never auto-export results. This closes the documented follow-up in PROGRESS.md ("AI/Visual job creation forms not yet wired with destinations").

## Changes
- `CreateJobDTO`: add `export_destination_ids` (plus `source_type`, `url_template`, which the AI flow already sent via an `as any` cast that is now removed).
- New pure helper `lib/jobs/buildAiJobPayload.ts` with Vitest coverage (6 tests) for query mapping + destination passthrough.
- AI page: `DestinationSelector` in the configure step; payload built via the helper.
- Visual builder: `DestinationSelector` in the save card; `export_destination_ids` passed to `jobsAPI.create`.

Backend already validates/persists/dispatches `export_destination_ids` (utils.py, job_manager.py); no backend change needed.

## Verification
- `vitest run`: 51/51 pass (8 files), incl. the 6 new helper tests.
- `tsc --noEmit`: zero new errors in changed files (pre-existing zod-resolver / test-setup errors are unrelated and predate this branch; they are why `ignoreBuildErrors` is set).

Filed by snowforge-autobuild cycle 2026-06-05.