### PR TITLE
fix(backend): repair production CSV fallback parser and green the unit suite

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,9 +1,16 @@
 # SnowScrape -- Progress & Launch Readiness
 
-**Last Updated:** 2026-06-05
+**Last Updated:** 2026-06-06
 **Launch Readiness:** ~98% (live; Google Docs destination backend complete, awaiting Alex's Google Cloud OAuth client + deploy)
-**Build Status:** PASSES
+**Build Status:** PASSES (backend unit suite 304/304 green as of 2026-06-06; was 11 red before today's fix)
 **Test Coverage:** ~60-70% (unit + integration; Playwright setup present)
+
+### Recent -- 2026-06-06
+- Backend red-signal fix (claude-main, pending Alex's merge to main). The backend unit suite was red: 11 failing tests (4 in `test_utils.py`, 7 in `test_ai_extractor.py`). Root causes and fixes:
+  - **Real production bug in CSV URL parsing.** `parse_links_from_file`'s pandas path is dead in production (pandas is intentionally not bundled in the Lambda, so it is not in `backend/pyproject.toml` and never imports), meaning the manual `csv.reader` fallback is the ONLY path that runs in prod. That fallback did not skip the header row, did not skip empty cells, and did not support the `'default'` auto-detect column option, so every CSV-sourced job ingested the header text as a bogus URL and could not auto-detect a URL column. Rewrote the fallback to mirror the pandas semantics (row 0 = header, resolve the column against the header, skip the header row and empty cells, support `'default'` via `detect_url_column`). 3 previously-failing `TestParseLinksFromFile` tests now encode the correct behavior and pass.
+  - **Stale auth test.** `test_extract_token_case_sensitive` asserted a lowercase `authorization` header yields no token, but `extract_token_from_event` deliberately accepts it (API Gateway V2 lowercases all header names). Corrected the test to match the intended, correct behavior.
+  - **AI-extractor test mock drift.** `test_ai_extractor.py` patches `ai_extractor.anthropic`, but the module lazy-imported `anthropic` inside `_get_client`, so the attribute did not exist at patch time (7 failures). Moved `import anthropic` to module scope (it is already a hard dependency); client construction stays lazy. No behavior change.
+  - Evidence: backend unit suite 304 passed / 0 failed (was 293 passed, 11 failed); integration suite 23 passed.
 
 ### Recent -- 2026-06-05
 - Frontend: wired the export-destination selector into the AI-assisted and Visual builder job-creation flows. Previously only the manual form rendered `DestinationSelector`; jobs created via AI/Visual silently dropped any chosen destinations and could never auto-export. Added `export_destination_ids` (plus `source_type`, `url_template`) to `CreateJobDTO`, extracted the `buildAiJobPayload` pure helper with 6 unit tests, and rendered `DestinationSelector` in both flows. Frontend suite 51/51 green. Merged to `claude-main` via PR #6; awaiting Alex's `claude-main -> main` review.

--- a/backend/ai_extractor.py
+++ b/backend/ai_extractor.py
@@ -11,6 +11,8 @@ import os
 import re
 from typing import Any, Dict, List, Optional
 
+import anthropic
+
 from logger import get_logger
 
 logger = get_logger(__name__)
@@ -35,7 +37,9 @@ def _get_client():
                 "ANTHROPIC_API_KEY environment variable is required for AI extraction. "
                 "Set it via: npx sst secret set AnthropicApiKey <key>"
             )
-        import anthropic
+        # `anthropic` is imported at module scope so tests can patch
+        # `ai_extractor.anthropic`; only client construction stays lazy
+        # (it needs the API key, absent at import time).
         _anthropic_client = anthropic.Anthropic(api_key=api_key)
     return _anthropic_client
 

--- a/backend/tests/unit/test_utils.py
+++ b/backend/tests/unit/test_utils.py
@@ -206,15 +206,16 @@ class TestExtractTokenFromEvent:
 		result = extract_token_from_event(event)
 		assert result == 'test-token-123'
 
-	def test_extract_token_case_sensitive(self):
-		"""Test that Authorization header is case-sensitive."""
+	def test_extract_token_lowercase_header(self):
+		"""API Gateway V2 lowercases header names, so a lowercase
+		'authorization' header must still yield the token."""
 		event = {
 			'headers': {
 				'authorization': 'Bearer test-token-123'
 			}
 		}
 		result = extract_token_from_event(event)
-		assert result is None
+		assert result == 'test-token-123'
 
 	def test_no_authorization_header(self):
 		"""Test extraction when Authorization header is missing."""

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -769,30 +769,43 @@ def parse_links_from_file(file_mapping, file_url):
 		# Step 2: If pandas fails, fallback to csv with manual file_mapping settings
 		logger.warning("Pandas failed to parse file, falling back to manual parsing", error=str(e))
 
-		# Manual parsing using csv.reader
+		# Manual parsing using csv.reader. Pandas is intentionally NOT bundled in the
+		# Lambda, so this fallback is the real production path. It must mirror the
+		# pandas-path semantics: row 0 is the header, the URL column is resolved
+		# against that header, and the header row plus any empty cells are skipped.
 		delimiter = file_mapping.get('delimiter', ',')
 		quotechar = None if file_mapping.get('enclosure') == 'none' else file_mapping.get('enclosure', None)
 		escapechar = None if file_mapping.get('escape') == 'none' else file_mapping.get('escape', None)
-		
+
 		reader = csv.reader(file_content.splitlines(), delimiter=delimiter, quotechar=quotechar, escapechar=escapechar)
-		
+		rows = list(reader)
+		if not rows:
+			return []
+
+		header = rows[0]
+		url_column = file_mapping['url_column']
+
+		# Resolve the URL column index against the header row.
+		if url_column == 'default':
+			url_column_index = detect_url_column(header)  # regex-detect a 'link'/'url' column
+			if url_column_index is None:
+				raise ValueError("No suitable URL column found matching 'link' or 'url'.")
+		elif isinstance(url_column, str):
+			if url_column in header:
+				url_column_index = header.index(url_column)
+			else:
+				raise Exception(f"Column '{url_column}' not found in header")
+		else:
+			url_column_index = url_column  # integer index
+
+		# Row 0 is the header; only data rows contribute URLs, and empty cells are skipped.
 		links = []
-		url_column_index = None  # Initialize the url_column_index variable
+		for row in rows[1:]:
+			if len(row) > url_column_index:
+				value = row[url_column_index].strip()
+				if value:
+					links.append(value)
 
-		for row_num, row in enumerate(reader):
-			# Handle the first row (header) if url_column is a string (header name)
-			if row_num == 0 and isinstance(file_mapping['url_column'], str):
-				if file_mapping['url_column'] in row:
-					url_column_index = row.index(file_mapping['url_column'])  # Find the index of the header
-				else:
-					raise Exception(f"Column '{file_mapping['url_column']}' not found in header")
-			elif isinstance(file_mapping['url_column'], int):
-				url_column_index = file_mapping['url_column']  # Use the integer as the column index
-
-			# Ensure url_column_index is set and the row has enough columns
-			if url_column_index is not None and len(row) > url_column_index:
-				links.append(row[url_column_index].strip())
-						
 		return links
 
 def refresh_job_urls(job_id, links):


### PR DESCRIPTION
## Summary
Repairs the red backend Python unit suite (was 293 passed / 11 failed) and fixes a real production bug it was masking.

### Production bug: CSV URL parsing fallback
`parse_links_from_file`'s pandas path is dead in production: pandas is intentionally not bundled in the Lambda (not in `backend/pyproject.toml`, not pulled transitively), so the manual `csv.reader` fallback is the ONLY path that runs in prod. That fallback:
- ingested the header row as a bogus URL (integer-column path never skipped row 0),
- did not skip empty cells,
- did not support the `'default'` auto-detect column option.

Rewrote the fallback to mirror the pandas semantics: row 0 is the header, the URL column is resolved against the header, the header row and empty cells are skipped, and `'default'` resolves via `detect_url_column`.

### Stale/mis-targeted tests
- `test_extract_token_case_sensitive` asserted a lowercase `authorization` header yields no token, but `extract_token_from_event` deliberately accepts it (API Gateway V2 lowercases header names). Corrected to assert the real, correct contract.
- `test_ai_extractor.py` patches `ai_extractor.anthropic`, which did not exist because `anthropic` was lazy-imported inside `_get_client` (7 failures). Moved `import anthropic` to module scope (already a hard dependency); client construction stays lazy. No behavior change.

## Evidence
- Backend unit suite: **304 passed / 0 failed** (was 293 passed, 11 failed)
- Backend integration suite: **23 passed**

## Independent review
Reviewed by a fresh adversarial reviewer subagent (diff-only). Verdict: approve, no high/medium findings; two optional LOW notes (use `.get('url_column')` for parity; pre-existing broad `except Exception` around the pandas path could mask fallback bugs, worth a separate ticket).

Filed by snowforge-autobuild cycle 2026-06-06.