### PR TITLE
feat(backend): authenticate the /jobs data-plane with API keys

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,7 @@
 **Test Coverage:** ~60-70% (unit + integration; Playwright setup present)
 
 ### Recent -- 2026-06-06
+- API-key auth wired across the entire /jobs data-plane (claude-main, pending Alex's merge to main). Programmatic API access (the launch "sub-project #2") was blocked because `validate_api_key` existed but was never called: every public endpoint still required a Clerk JWT, so the Settings -> API Keys feature produced keys that did not actually authenticate anything. Added a single auth resolver `resolve_user_id(token)` in `utils.py` that accepts either a SnowScrape API key (`sk_live_...`, checked first by prefix) or a Clerk session JWT, returning the owning user_id (raising on an invalid credential so callers keep their existing 401 path). Wired it into all 13 /jobs data-plane handlers (create, list/status, get, update, delete, pause, cancel, resume, refresh, crawls list+get, download, preview). Control-plane endpoints (api-keys CRUD, billing, integrations/OAuth, templates, webhooks, destinations) intentionally stay Clerk-only. Billing gates are unaffected: they key off user_id, which the resolver supplies for API-key callers too. TDD: 4 resolver unit tests + 2 end-to-end API-key integration tests (valid key authenticates a /jobs read; revoked key -> 401). Evidence: full backend suite 333 passed (308 unit + 25 integration), up from 327.
 - Backend red-signal fix (claude-main, pending Alex's merge to main). The backend unit suite was red: 11 failing tests (4 in `test_utils.py`, 7 in `test_ai_extractor.py`). Root causes and fixes:
   - **Real production bug in CSV URL parsing.** `parse_links_from_file`'s pandas path is dead in production (pandas is intentionally not bundled in the Lambda, so it is not in `backend/pyproject.toml` and never imports), meaning the manual `csv.reader` fallback is the ONLY path that runs in prod. That fallback did not skip the header row, did not skip empty cells, and did not support the `'default'` auto-detect column option, so every CSV-sourced job ingested the header text as a bogus URL and could not auto-detect a URL column. Rewrote the fallback to mirror the pandas semantics (row 0 = header, resolve the column against the header, skip the header row and empty cells, support `'default'` via `detect_url_column`). 3 previously-failing `TestParseLinksFromFile` tests now encode the correct behavior and pass.
   - **Stale auth test.** `test_extract_token_case_sensitive` asserted a lowercase `authorization` header yields no token, but `extract_token_from_event` deliberately accepts it (API Gateway V2 lowercases all header names). Corrected the test to match the intended, correct behavior.
@@ -118,10 +119,11 @@
 - Dashboard pages exist but display mock/placeholder data
 - No real analytics pipeline connected
 
-### API Key Authentication (Backend complete, public-endpoint auth not wired)
+### API Key Authentication (jobs data-plane wired on claude-main; control-plane still Clerk-only)
 - Backend `api_key_handler.py` and Settings → API Keys tab fully implemented (one-time-secret modal, list/create/revoke)
 - API keys can be created and managed
-- BUT: external API calls to `/jobs` etc. still require Clerk JWT -- there's no `Authorization: Bearer sk_live_...` middleware yet
+- DONE (claude-main, 2026-06-06): `Authorization: Bearer sk_live_...` now authenticates the entire `/jobs` data-plane via `resolve_user_id` (create, list, get, update, delete, pause, cancel, resume, refresh, crawls, download, preview)
+- Remaining: decide whether to extend API-key auth to the other data endpoints (templates, webhooks, export destinations); the control-plane (api-keys CRUD, billing, integrations/OAuth) stays Clerk-only by design. Public API docs / a quickstart for programmatic use would also help.
 - Sub-project #2 of launch sequence
 
 ### Notification System (Partial)
@@ -142,7 +144,7 @@
 | Work Item | Estimate | Priority |
 |-----------|----------|----------|
 | First real $0 trial signup as final live smoke | hours | CRITICAL -- final acceptance |
-| API key auth on public endpoints | 1 week | MEDIUM |
+| API key auth on public endpoints | jobs data-plane DONE (2026-06-06); optional: extend to templates/webhooks/destinations + write API docs | MEDIUM |
 | Real analytics data pipeline | 2-3 weeks | HIGH |
 | Email notifications | 1 week | MEDIUM |
 | In-app notification center | 1 week | LOW |

--- a/backend/handler.py
+++ b/backend/handler.py
@@ -14,7 +14,7 @@ from logger import get_logger, log_lambda_invocation, log_exception
 from metrics import get_metrics_emitter
 from observatory_client import get_observatory_client
 from urllib.parse import urlparse
-from utils import decimal_to_float, detect_csv_settings, extract_token_from_event, get_links_for_job, parse_links_from_file, preview_url_template, refresh_job_urls, validate_clerk_token, validate_job_data, verify_resource_ownership
+from utils import decimal_to_float, detect_csv_settings, extract_token_from_event, get_links_for_job, parse_links_from_file, preview_url_template, refresh_job_urls, resolve_user_id, validate_clerk_token, validate_job_data, verify_resource_ownership
 from cache import cache_get, cache_set, cache_delete
 from webhook_dispatcher import WebhookDispatcher
 from proxy_manager import get_proxy_manager
@@ -169,8 +169,8 @@ def create_job_handler(event, context):
 			}
 
 		try:
-			user_data = validate_clerk_token(token)
-			logger.info("User authenticated", user_id=user_data.get("sub"))
+			user_id = resolve_user_id(token)
+			logger.info("User authenticated", user_id=user_id)
 		except Exception as e:
 			logger.warning("Token validation failed", error=str(e))
 			duration_ms = (time.time() - start_time) * 1000
@@ -187,7 +187,7 @@ def create_job_handler(event, context):
 		# Parse and validate job data
 		job_data = json.loads(event['body'])
 		validate_job_data(job_data)
-		job_data["user_id"] = user_data["sub"]
+		job_data["user_id"] = user_id
 
 		# ── Billing enforcement (fail-CLOSED on inactive sub, fail-open on errors) ──
 		try:
@@ -197,7 +197,7 @@ def create_job_handler(event, context):
 			)
 
 			# Hard gate: subscription must be active/trialing
-			sub = get_subscription(user_data["sub"])
+			sub = get_subscription(user_id)
 			if not is_subscription_active(sub):
 				return {
 					"statusCode": 402,
@@ -213,7 +213,7 @@ def create_job_handler(event, context):
 				}
 
 			# Check page quota
-			quota = check_usage_quota(user_data["sub"])
+			quota = check_usage_quota(user_id)
 			if not quota["allowed"]:
 				return {
 					"statusCode": 402,
@@ -230,7 +230,7 @@ def create_job_handler(event, context):
 				}
 
 			# Check concurrent job limit
-			concurrent = check_concurrent_job_limit(user_data["sub"])
+			concurrent = check_concurrent_job_limit(user_id)
 			if not concurrent["allowed"]:
 				return {
 					"statusCode": 429,
@@ -249,7 +249,7 @@ def create_job_handler(event, context):
 			# Check feature access for premium features
 			render_config = job_data.get("render_config") or job_data.get("rendering") or {}
 			if render_config.get("enabled"):
-				feature = check_feature_access(user_data["sub"], "js_rendering")
+				feature = check_feature_access(user_id, "js_rendering")
 				if not feature["allowed"]:
 					return {
 						"statusCode": 403,
@@ -265,7 +265,7 @@ def create_job_handler(event, context):
 
 			proxy_config = job_data.get("proxy_config") or job_data.get("proxy") or {}
 			if proxy_config.get("enabled"):
-				feature = check_feature_access(user_data["sub"], "proxy_rotation")
+				feature = check_feature_access(user_id, "proxy_rotation")
 				if not feature["allowed"]:
 					return {
 						"statusCode": 403,
@@ -285,14 +285,14 @@ def create_job_handler(event, context):
 						   error=str(billing_err))
 		# ── End billing enforcement ───────────────────────────────────
 
-		logger.info("Creating job", job_name=job_data.get('name'), user_id=user_data.get("sub"))
+		logger.info("Creating job", job_name=job_data.get('name'), user_id=user_id)
 
 		# Create job
 		job_id = create_job(job_data)
 
 		if job_id:
 			# Invalidate user's job list cache
-			cache_delete(f"jobs:{user_data['sub']}")
+			cache_delete(f"jobs:{user_id}")
 			logger.log_job_event(job_id, 'created', 'ready', job_name=job_data.get('name'))
 
 			# Emit custom metrics for job creation
@@ -375,8 +375,7 @@ def delete_job_handler(event, context):
 		}
 
 	try:
-		user_data = validate_clerk_token(token)
-		user_id = user_data.get("sub")
+		user_id = resolve_user_id(token)
 	except Exception as e:
 		return {
 			"statusCode": 401,
@@ -451,8 +450,7 @@ def get_all_job_statuses_handler(event, context):
 			}
 
 		try:
-			user_data = validate_clerk_token(token)
-			user_id = user_data.get("sub")
+			user_id = resolve_user_id(token)
 		except Exception as e:
 			return {
 				"statusCode": 401,
@@ -533,8 +531,7 @@ def get_crawl_handler(event, context):
 		}
 
 	try:
-		user_data = validate_clerk_token(token)
-		user_id = user_data.get("sub")
+		user_id = resolve_user_id(token)
 	except Exception as e:
 		return {
 			"statusCode": 401,
@@ -612,8 +609,7 @@ def get_job_crawls_handler(event, context):
 		}
 
 	try:
-		user_data = validate_clerk_token(token)
-		user_id = user_data.get("sub")
+		user_id = resolve_user_id(token)
 	except Exception as e:
 		return {
 			"statusCode": 401,
@@ -679,8 +675,7 @@ def get_job_details_handler(event, context):
 		}
 
 	try:
-		user_data = validate_clerk_token(token)
-		user_id = user_data.get("sub")
+		user_id = resolve_user_id(token)
 	except Exception as e:
 		return {
 			"statusCode": 401,
@@ -753,8 +748,7 @@ def pause_job_handler(event, context):
 		}
 
 	try:
-		user_data = validate_clerk_token(token)
-		user_id = user_data.get("sub")
+		user_id = resolve_user_id(token)
 	except Exception as e:
 		return {
 			"statusCode": 401,
@@ -820,8 +814,7 @@ def cancel_job_handler(event, context):
 		}
 
 	try:
-		user_data = validate_clerk_token(token)
-		user_id = user_data.get("sub")
+		user_id = resolve_user_id(token)
 	except Exception as e:
 		return {
 			"statusCode": 401,
@@ -1070,8 +1063,7 @@ def refresh_job_handler(event, context):
 		}
 
 	try:
-		user_data = validate_clerk_token(token)
-		user_id = user_data.get("sub")
+		user_id = resolve_user_id(token)
 	except Exception as e:
 		return {
 			"statusCode": 401,
@@ -1137,8 +1129,7 @@ def resume_job_handler(event, context):
 		}
 
 	try:
-		user_data = validate_clerk_token(token)
-		user_id = user_data.get("sub")
+		user_id = resolve_user_id(token)
 	except Exception as e:
 		return {
 			"statusCode": 401,
@@ -1461,8 +1452,7 @@ def update_job_handler(event, context):
 		}
 
 	try:
-		user_data = validate_clerk_token(token)
-		user_id = user_data.get("sub")
+		user_id = resolve_user_id(token)
 	except Exception as e:
 		return {
 			"statusCode": 401,
@@ -1726,8 +1716,7 @@ def download_results_handler(event, context):
 			}
 
 		try:
-			user_data = validate_clerk_token(token)
-			user_id = user_data.get("sub")
+			user_id = resolve_user_id(token)
 			logger.info("User authenticated", user_id=user_id)
 		except Exception as e:
 			logger.warning("Token validation failed", error=str(e))
@@ -1926,8 +1915,7 @@ def preview_results_handler(event, context):
 			}
 
 		try:
-			user_data = validate_clerk_token(token)
-			user_id = user_data.get("sub")
+			user_id = resolve_user_id(token)
 			logger.info("User authenticated", user_id=user_id)
 		except Exception as e:
 			logger.warning("Token validation failed", error=str(e))

--- a/backend/tests/integration/test_billing_flow.py
+++ b/backend/tests/integration/test_billing_flow.py
@@ -21,7 +21,7 @@ class TestLockedUserAccess:
 				"rate_limit": 5,
 			}),
 		}
-		with patch("handler.validate_clerk_token", return_value={"sub": "user-locked"}):
+		with patch("handler.resolve_user_id", return_value="user-locked"):
 			resp = create_job_handler(event, lambda_context)
 		assert resp["statusCode"] == 402
 		body = json.loads(resp["body"])
@@ -32,7 +32,7 @@ class TestLockedUserAccess:
 	):
 		from handler import get_all_job_statuses_handler
 		event = {"headers": {"Authorization": "Bearer t"}}
-		with patch("handler.validate_clerk_token", return_value={"sub": "user-locked"}):
+		with patch("handler.resolve_user_id", return_value="user-locked"):
 			resp = get_all_job_statuses_handler(event, lambda_context)
 		# 200 with empty list — read access preserved for locked users
 		assert resp["statusCode"] == 200

--- a/backend/tests/integration/test_handlers.py
+++ b/backend/tests/integration/test_handlers.py
@@ -20,12 +20,12 @@ class TestHandlers:
 		_conc_ok = {'allowed': True, 'plan': 'pro', 'status': 'trialing', 'active_jobs': 0, 'limit': 5}
 
 		with patch('utils.parse_links_from_file') as mock_parse:
-			with patch('handler.validate_clerk_token') as mock_validate:
+			with patch('handler.resolve_user_id') as mock_validate:
 				with patch('billing.get_subscription', return_value=_sub_active):
 					with patch('billing.check_usage_quota', return_value=_quota_ok):
 						with patch('billing.check_concurrent_job_limit', return_value=_conc_ok):
 							mock_parse.return_value = ['http://test1.com', 'http://test2.com']
-							mock_validate.return_value = {'sub': 'user-123'}
+							mock_validate.return_value = 'user-123'
 
 							event = {
 								'headers': {
@@ -92,7 +92,7 @@ class TestHandlers:
 		"""Test job creation with invalid authentication token."""
 		from handler import create_job_handler
 
-		with patch('handler.validate_clerk_token') as mock_validate:
+		with patch('handler.resolve_user_id') as mock_validate:
 			mock_validate.side_effect = Exception('Invalid token.')
 
 			event = {
@@ -122,6 +122,50 @@ class TestHandlers:
 			assert response['statusCode'] == 401
 
 	@mock_aws
+	def test_jobs_handler_accepts_api_key(self, dynamodb_client, mock_env_vars, lambda_context):
+		"""An sk_live_ API key authenticates a /jobs data-plane request end to end
+		(no auth mocking: this exercises resolve_user_id -> validate_api_key)."""
+		import hashlib
+		from handler import get_all_job_statuses_handler
+
+		raw_key = 'sk_live_' + 'k' * 32
+		key_hash = hashlib.sha256(raw_key.encode('utf-8')).hexdigest()
+		dynamodb_client.Table('SnowscrapeApiKeys-test').put_item(Item={
+			'api_key_id': 'ak_test_1',
+			'user_id': 'user-apikey-1',
+			'key_hash': key_hash,
+			'key_prefix': raw_key[:12],
+			'is_active': True,
+		})
+
+		event = {'headers': {'Authorization': f'Bearer {raw_key}'}}
+		response = get_all_job_statuses_handler(event, lambda_context)
+
+		# Read access is granted via the API key; this user has no jobs yet.
+		assert response['statusCode'] == 200
+
+	@mock_aws
+	def test_jobs_handler_rejects_inactive_api_key(self, dynamodb_client, mock_env_vars, lambda_context):
+		"""A revoked (is_active=False) API key is rejected with 401."""
+		import hashlib
+		from handler import get_all_job_statuses_handler
+
+		raw_key = 'sk_live_' + 'r' * 32
+		key_hash = hashlib.sha256(raw_key.encode('utf-8')).hexdigest()
+		dynamodb_client.Table('SnowscrapeApiKeys-test').put_item(Item={
+			'api_key_id': 'ak_test_revoked',
+			'user_id': 'user-apikey-2',
+			'key_hash': key_hash,
+			'key_prefix': raw_key[:12],
+			'is_active': False,
+		})
+
+		event = {'headers': {'Authorization': f'Bearer {raw_key}'}}
+		response = get_all_job_statuses_handler(event, lambda_context)
+
+		assert response['statusCode'] == 401
+
+	@mock_aws
 	def test_delete_job_handler_success(self, dynamodb_client, mock_env_vars, lambda_context):
 		"""Test successful job deletion via handler."""
 		from handler import create_job_handler, delete_job_handler
@@ -132,12 +176,12 @@ class TestHandlers:
 
 		# First create a job
 		with patch('utils.parse_links_from_file') as mock_parse:
-			with patch('handler.validate_clerk_token') as mock_validate:
+			with patch('handler.resolve_user_id') as mock_validate:
 				with patch('billing.get_subscription', return_value=_sub_active):
 					with patch('billing.check_usage_quota', return_value=_quota_ok):
 						with patch('billing.check_concurrent_job_limit', return_value=_conc_ok):
 							mock_parse.return_value = ['http://test1.com']
-							mock_validate.return_value = {'sub': 'user-123'}
+							mock_validate.return_value = 'user-123'
 
 							create_event = {
 								'headers': {'Authorization': 'Bearer test-token'},
@@ -201,12 +245,12 @@ class TestHandlers:
 
 		# First create a job
 		with patch('utils.parse_links_from_file') as mock_parse:
-			with patch('handler.validate_clerk_token') as mock_validate:
+			with patch('handler.resolve_user_id') as mock_validate:
 				with patch('billing.get_subscription', return_value=_sub_active):
 					with patch('billing.check_usage_quota', return_value=_quota_ok):
 						with patch('billing.check_concurrent_job_limit', return_value=_conc_ok):
 							mock_parse.return_value = ['http://test1.com']
-							mock_validate.return_value = {'sub': 'user-123'}
+							mock_validate.return_value = 'user-123'
 
 							create_event = {
 								'headers': {'Authorization': 'Bearer test-token'},
@@ -249,8 +293,8 @@ class TestHandlers:
 		"""Test retrieving non-existent job details."""
 		from handler import get_job_details_handler
 
-		with patch('handler.validate_clerk_token') as mock_validate:
-			mock_validate.return_value = {'sub': 'user-123'}
+		with patch('handler.resolve_user_id') as mock_validate:
+			mock_validate.return_value = 'user-123'
 
 			event = {
 				'headers': {'Authorization': 'Bearer test-token'},
@@ -274,12 +318,12 @@ class TestHandlers:
 
 		# First create a job
 		with patch('utils.parse_links_from_file') as mock_parse:
-			with patch('handler.validate_clerk_token') as mock_validate:
+			with patch('handler.resolve_user_id') as mock_validate:
 				with patch('billing.get_subscription', return_value=_sub_active):
 					with patch('billing.check_usage_quota', return_value=_quota_ok):
 						with patch('billing.check_concurrent_job_limit', return_value=_conc_ok):
 							mock_parse.return_value = ['http://test1.com']
-							mock_validate.return_value = {'sub': 'user-123'}
+							mock_validate.return_value = 'user-123'
 
 							create_event = {
 								'headers': {'Authorization': 'Bearer test-token'},
@@ -327,12 +371,12 @@ class TestHandlers:
 
 		# First create a job
 		with patch('utils.parse_links_from_file') as mock_parse:
-			with patch('handler.validate_clerk_token') as mock_validate:
+			with patch('handler.resolve_user_id') as mock_validate:
 				with patch('billing.get_subscription', return_value=_sub_active):
 					with patch('billing.check_usage_quota', return_value=_quota_ok):
 						with patch('billing.check_concurrent_job_limit', return_value=_conc_ok):
 							mock_parse.return_value = ['http://test1.com']
-							mock_validate.return_value = {'sub': 'user-123'}
+							mock_validate.return_value = 'user-123'
 
 							create_event = {
 								'headers': {'Authorization': 'Bearer test-token'},
@@ -380,12 +424,12 @@ class TestHandlers:
 
 		# Create multiple jobs
 		with patch('utils.parse_links_from_file') as mock_parse:
-			with patch('handler.validate_clerk_token') as mock_validate:
+			with patch('handler.resolve_user_id') as mock_validate:
 				with patch('billing.get_subscription', return_value=_sub_active):
 					with patch('billing.check_usage_quota', return_value=_quota_ok):
 						with patch('billing.check_concurrent_job_limit', return_value=_conc_ok):
 							mock_parse.return_value = ['http://test1.com']
-							mock_validate.return_value = {'sub': 'user-123'}
+							mock_validate.return_value = 'user-123'
 
 							for i in range(3):
 								create_event = {
@@ -433,12 +477,12 @@ class TestHandlers:
 
 		# First create a job
 		with patch('utils.parse_links_from_file') as mock_parse:
-			with patch('handler.validate_clerk_token') as mock_validate:
+			with patch('handler.resolve_user_id') as mock_validate:
 				with patch('billing.get_subscription', return_value=_sub_active):
 					with patch('billing.check_usage_quota', return_value=_quota_ok):
 						with patch('billing.check_concurrent_job_limit', return_value=_conc_ok):
 							mock_parse.return_value = ['http://test1.com']
-							mock_validate.return_value = {'sub': 'user-123'}
+							mock_validate.return_value = 'user-123'
 
 							create_event = {
 								'headers': {'Authorization': 'Bearer test-token'},

--- a/backend/tests/integration/test_handlers.py
+++ b/backend/tests/integration/test_handlers.py
@@ -138,11 +138,19 @@ class TestHandlers:
 			'is_active': True,
 		})
 
+		# Seed one job owned by the key's user and one owned by someone else, to
+		# prove the API key resolves to the right user_id AND that ownership scoping holds.
+		jobs_table = dynamodb_client.Table('SnowscrapeJobs-test')
+		jobs_table.put_item(Item={'job_id': 'job-mine', 'user_id': 'user-apikey-1', 'status': 'completed', 'name': 'Mine'})
+		jobs_table.put_item(Item={'job_id': 'job-theirs', 'user_id': 'user-other', 'status': 'completed', 'name': 'Theirs'})
+
 		event = {'headers': {'Authorization': f'Bearer {raw_key}'}}
 		response = get_all_job_statuses_handler(event, lambda_context)
 
-		# Read access is granted via the API key; this user has no jobs yet.
 		assert response['statusCode'] == 200
+		body = json.loads(response['body'])
+		returned_ids = {job['job_id'] for job in body['jobs']}
+		assert returned_ids == {'job-mine'}  # scoped to the key's user, never job-theirs
 
 	@mock_aws
 	def test_jobs_handler_rejects_inactive_api_key(self, dynamodb_client, mock_env_vars, lambda_context):

--- a/backend/tests/unit/test_utils.py
+++ b/backend/tests/unit/test_utils.py
@@ -263,6 +263,13 @@ class TestResolveUserId:
 			with pytest.raises(Exception, match='Token expired.'):
 				resolve_user_id('eyJ.bad.jwt')
 
+	def test_clerk_jwt_without_sub_raises(self):
+		"""A token that decodes but carries no 'sub' must NOT resolve to a None
+		user_id (which ownership checks would otherwise honor); it must raise."""
+		with patch('utils.validate_clerk_token', return_value={'foo': 'bar'}):
+			with pytest.raises(Exception, match='[Mm]issing subject'):
+				resolve_user_id('eyJ.subless.jwt')
+
 	def test_api_key_returns_owner_user_id(self):
 		"""An sk_live_ key is validated via validate_api_key; user_id comes from the key record."""
 		with patch('api_key_handler.validate_api_key', return_value={'user_id': 'user_api_1', 'api_key_id': 'ak_1'}) as mock_key, \

--- a/backend/tests/unit/test_utils.py
+++ b/backend/tests/unit/test_utils.py
@@ -9,6 +9,7 @@ from utils import (
 	detect_url_column,
 	extract_token_from_event,
 	parse_links_from_file,
+	resolve_user_id,
 	validate_job_data,
 	fetch_file_content
 )
@@ -242,6 +243,43 @@ class TestExtractTokenFromEvent:
 		}
 		result = extract_token_from_event(event)
 		assert result == ''
+
+
+class TestResolveUserId:
+	"""Unit tests for resolve_user_id: the unified auth resolver that accepts
+	either a SnowScrape API key (sk_live_...) or a Clerk session JWT and returns
+	the owning user_id, raising on an invalid credential."""
+
+	def test_clerk_jwt_returns_sub(self):
+		"""A non-API-key token is validated as a Clerk JWT; user_id is its 'sub'."""
+		with patch('utils.validate_clerk_token', return_value={'sub': 'user_clerk_1'}) as mock_clerk:
+			result = resolve_user_id('eyJ.clerk.jwt')
+		assert result == 'user_clerk_1'
+		mock_clerk.assert_called_once_with('eyJ.clerk.jwt')
+
+	def test_invalid_clerk_jwt_propagates(self):
+		"""An invalid Clerk JWT raises, so callers keep their existing 401 path."""
+		with patch('utils.validate_clerk_token', side_effect=Exception('Token expired.')):
+			with pytest.raises(Exception, match='Token expired.'):
+				resolve_user_id('eyJ.bad.jwt')
+
+	def test_api_key_returns_owner_user_id(self):
+		"""An sk_live_ key is validated via validate_api_key; user_id comes from the key record."""
+		with patch('api_key_handler.validate_api_key', return_value={'user_id': 'user_api_1', 'api_key_id': 'ak_1'}) as mock_key, \
+				patch('utils.validate_clerk_token') as mock_clerk:
+			result = resolve_user_id('sk_live_abc123')
+		assert result == 'user_api_1'
+		mock_key.assert_called_once_with('sk_live_abc123')
+		# An API key must NOT fall through to Clerk validation.
+		mock_clerk.assert_not_called()
+
+	def test_invalid_api_key_raises(self):
+		"""An sk_live_ key that does not resolve raises and never falls back to Clerk."""
+		with patch('api_key_handler.validate_api_key', return_value=None), \
+				patch('utils.validate_clerk_token') as mock_clerk:
+			with pytest.raises(Exception, match='[Ii]nvalid API key'):
+				resolve_user_id('sk_live_revoked')
+		mock_clerk.assert_not_called()
 
 
 class TestValidateJobData:

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -274,6 +274,31 @@ def extract_token_from_event(event):
 		return authorization_header[len("Bearer "):]
 	return None
 
+def resolve_user_id(token):
+	"""Resolve a bearer token to the owning user_id.
+
+	Accepts either a SnowScrape API key (sk_live_...) for programmatic access or
+	a Clerk session JWT from the dashboard. API keys are detected by prefix and
+	checked first; on a missing/revoked key this raises rather than falling
+	through to Clerk validation (which would always fail for a non-JWT anyway).
+	Anything without the API-key prefix is validated as a Clerk JWT.
+
+	Raises on an invalid credential, mirroring validate_clerk_token's contract so
+	callers keep their existing 401 handling.
+	"""
+	# Lazy import: api_key_handler imports from utils at module load, so importing
+	# it at module scope here would create a circular import.
+	from api_key_handler import API_KEY_PREFIX, validate_api_key
+
+	if token and token.startswith(API_KEY_PREFIX):
+		key_record = validate_api_key(token)
+		if not key_record:
+			raise Exception("Invalid API key")
+		return key_record["user_id"]
+
+	user_data = validate_clerk_token(token)
+	return user_data.get("sub")
+
 # Use this function for each URL request, and pass the session across requests within the job
 def fetch_url_with_session(url: str, session: Session, job_id: str, proxy_config: dict = None, render_config: dict = None) -> dict:
 	"""

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -297,7 +297,12 @@ def resolve_user_id(token):
 		return key_record["user_id"]
 
 	user_data = validate_clerk_token(token)
-	return user_data.get("sub")
+	user_id = user_data.get("sub")
+	if not user_id:
+		# A token can decode yet lack a subject; treat it as unauthenticated
+		# rather than returning a None user_id that ownership checks would honor.
+		raise Exception("Invalid token: missing subject")
+	return user_id
 
 # Use this function for each URL request, and pass the session across requests within the job
 def fetch_url_with_session(url: str, session: Session, job_id: str, proxy_config: dict = None, render_config: dict = None) -> dict:


### PR DESCRIPTION
## What
Wires `sk_live_` API keys into the entire `/jobs` data-plane so programmatic API access (launch sub-project #2) actually works. `validate_api_key` existed but was never called, so created keys authenticated nothing.

## How
- New `resolve_user_id(token)` in `backend/utils.py`: accepts an API key (`sk_live_...`, checked first by prefix) or a Clerk JWT, returns the owning user_id, raises on any invalid credential (including a sub-less JWT) so callers keep their 401 path. Lazy import of `api_key_handler` avoids the circular import.
- Wired into all 13 `/jobs` handlers (create, list, get, update, delete, pause, cancel, resume, refresh, crawls list+get, download, preview).
- Control-plane endpoints (api-keys CRUD, billing, integrations/OAuth, templates, webhooks, destinations) intentionally stay Clerk-only.
- Billing gates unaffected (they key off user_id).

## Tests
- 5 resolver unit tests (API key valid/invalid, Clerk valid/invalid, sub-less JWT raises).
- 2 end-to-end API-key integration tests against moto (valid key is user-scoped; revoked key -> 401).
- Full backend suite: **334 passed** (309 unit + 25 integration).

## Self-review
Independent adversarial review run on the diff: no high/medium correctness or security findings after fixes (sub-less JWT now raises; API-key test asserts user-scoping). Ownership checks (`verify_resource_ownership`) intact; no control-plane handler accepts API keys.

Filed by snowforge-autobuild cycle 2026-06-06.