### PR TITLE
Fix backend integration tests: lazy AWS resource resolution in utils (#16)

### DIFF
--- a/backend/tests/unit/test_utils.py
+++ b/backend/tests/unit/test_utils.py
@@ -713,7 +713,10 @@ class TestLazyAwsResourceResolution:
 		"""Each URL helper must fetch the URLs table via get_table when invoked."""
 		import os
 		import utils
+		# pytest-env seeds this, but conftest's mock_env_vars fixture deletes it on
+		# teardown, so set it explicitly to stay order-independent in the full suite.
 		os.environ['DYNAMODB_URLS_TABLE'] = 'SnowscrapeUrls-test'
+		expected_table = 'SnowscrapeUrls-test'
 
 		fake_table = MagicMock()
 		fake_table.query.return_value = {'Items': []}
@@ -725,12 +728,13 @@ class TestLazyAwsResourceResolution:
 
 		assert mock_get_table.call_count >= 4
 		for call in mock_get_table.call_args_list:
-			assert call.args[0] == 'SnowscrapeUrls-test'
+			assert call.args[0] == expected_table
 
 	def test_delete_s3_result_file_resolves_client_at_call_time(self):
 		"""delete_s3_result_file must fetch the S3 client via get_s3_client when invoked."""
 		import os
 		import utils
+		# Set explicitly: conftest's mock_env_vars fixture deletes S3_BUCKET on teardown.
 		os.environ['S3_BUCKET'] = 'snowscrape-results-test'
 
 		fake_s3 = MagicMock()

--- a/backend/tests/unit/test_utils.py
+++ b/backend/tests/unit/test_utils.py
@@ -687,3 +687,55 @@ class TestParseLinksFromFile:
 		result = parse_links_from_file(file_mapping, url)
 		assert 'http://test1.com' in result
 		assert 'http://test2.com' in result
+
+
+class TestLazyAwsResourceResolution:
+	"""Regression tests for the import-time AWS resource binding bug (issue #16).
+
+	utils.py used to bind ``s3``, ``job_table`` and ``url_table`` to connection-pool
+	resources at module import time. That pinned each resource to whatever
+	credentials resolved during import, which broke the backend integration suite on
+	CI (no ambient AWS credentials at import; moto/test credentials are set up
+	per-test, after import) with NoCredentialsError, and defeated the per-test
+	connection-pool reset in conftest. The fix fetches the table/client lazily at
+	call time. These tests fail against the old import-time-binding code.
+	"""
+
+	def test_no_import_time_aws_resources_bound(self):
+		"""The fragile import-time globals must not exist on the module."""
+		import utils
+		for name in ('url_table', 'job_table', 's3'):
+			assert not hasattr(utils, name), (
+				f"utils.{name} is bound at import time; resolve it lazily at call time"
+			)
+
+	def test_url_helpers_resolve_table_at_call_time(self):
+		"""Each URL helper must fetch the URLs table via get_table when invoked."""
+		import os
+		import utils
+		os.environ['DYNAMODB_URLS_TABLE'] = 'SnowscrapeUrls-test'
+
+		fake_table = MagicMock()
+		fake_table.query.return_value = {'Items': []}
+		with patch('utils.get_table', return_value=fake_table) as mock_get_table:
+			utils.delete_job_links('job-1')
+			utils.fetch_urls_for_job('job-1')
+			utils.update_url_status('job-1', 'http://x.test', 'done')
+			utils.refresh_job_urls('job-1', ['http://x.test'])
+
+		assert mock_get_table.call_count >= 4
+		for call in mock_get_table.call_args_list:
+			assert call.args[0] == 'SnowscrapeUrls-test'
+
+	def test_delete_s3_result_file_resolves_client_at_call_time(self):
+		"""delete_s3_result_file must fetch the S3 client via get_s3_client when invoked."""
+		import os
+		import utils
+		os.environ['S3_BUCKET'] = 'snowscrape-results-test'
+
+		fake_s3 = MagicMock()
+		with patch('utils.get_s3_client', return_value=fake_s3) as mock_get_s3:
+			utils.delete_s3_result_file('job-1')
+
+		mock_get_s3.assert_called_once()
+		fake_s3.delete_object.assert_called_once()

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -36,10 +36,10 @@ from validators import validate_scrape_url, ValidationError as ScrapeValidationE
 
 logger = get_logger(__name__)
 
-# Use connection pool for AWS services
-s3 = get_s3_client()
-job_table = get_table(os.environ['DYNAMODB_JOBS_TABLE'])
-url_table = get_table(os.environ['DYNAMODB_URLS_TABLE'])
+# AWS service clients/tables are fetched lazily at call time via the connection
+# pool (get_s3_client / get_table). Binding them at import time pins the resource
+# to whatever credentials resolved during import, which breaks under test (moto
+# credentials are set up per-test, after import) and defeats the pool reset.
 
 # Define a list of common user agents and referrers
 REFERRERS = [
@@ -189,6 +189,7 @@ def decimal_to_float(obj):
 # Helper function to delete all URLs associated with the job
 def delete_job_links(job_id):
 	try:
+		url_table = get_table(os.environ['DYNAMODB_URLS_TABLE'])
 		# Query the url_table to get all links for the given job_id
 		response = url_table.query(
 			KeyConditionExpression=boto3.dynamodb.conditions.Key('job_id').eq(job_id)
@@ -214,6 +215,7 @@ def delete_job_links(job_id):
 # Helper function to delete the S3 result file for the job
 def delete_s3_result_file(job_id):
 	try:
+		s3 = get_s3_client()
 		s3.delete_object(Bucket=os.environ['S3_BUCKET'], Key=f'jobs/{job_id}/result.json')
 		logger.info("Deleted result file from S3", job_id=job_id)
 	
@@ -487,6 +489,7 @@ def fetch_urls_for_job(job_id: str) -> list:
 	Query DynamoDB to fetch all URLs associated with the given job_id.
 	"""
 	try:
+		url_table = get_table(os.environ['DYNAMODB_URLS_TABLE'])
 		response = url_table.query(
 			KeyConditionExpression=boto3.dynamodb.conditions.Key('job_id').eq(job_id)
 		)
@@ -844,6 +847,7 @@ def refresh_job_urls(job_id, links):
 	If the job already has URLs, they will be replaced with the new links.
 	"""
 	try:
+		url_table = get_table(os.environ['DYNAMODB_URLS_TABLE'])
 		# First, delete existing URLs for the job
 		existing_urls = url_table.query(
 			KeyConditionExpression=Key('job_id').eq(job_id)
@@ -998,6 +1002,7 @@ def update_url_status(job_id: str, url: str, status: str) -> None:
 	- status (str): The new status for the URL.
 	"""
 	try:
+		url_table = get_table(os.environ['DYNAMODB_URLS_TABLE'])
 		url_table.update_item(
 			Key={'job_id': job_id, 'url': url},
 			UpdateExpression="SET #status = :status",


### PR DESCRIPTION
## Red signal
Backend CI `Backend Tests` failed on `test_delete_job_handler_success` with `NoCredentialsError` (issue #16). Only the delete test failed; all others passed.

## Root cause
`utils.py` bound `s3`, `job_table`, and `url_table` to connection-pool resources **at module import time**. That pins each resource to whatever credentials resolved during import. On CI there are no ambient AWS credentials at import (moto/test credentials are set up per-test, after import), so `delete_job_links` -> `url_table.query` reached real boto3 with no creds and raised `NoCredentialsError`. It passed locally only because the dev machine has ambient AWS creds. The import-time binding also defeated the per-test connection-pool reset in `conftest.py`.

Failing call chain: `delete_job_handler` -> `delete_job` -> `delete_job_links` -> `utils.py:193 url_table.query`.

## Fix
Fetch the URLs table and S3 client lazily at call time via `get_table` / `get_s3_client` (the pattern the rest of the code already uses, e.g. job_manager and lines 972-973). Removed the now-dead import-time `job_table` global. Affected helpers: `delete_job_links`, `fetch_urls_for_job`, `update_url_status`, `refresh_job_urls`, `delete_s3_result_file`.

## Tests
- Added `TestLazyAwsResourceResolution` (3 tests): asserts no import-time AWS globals exist and that the URL/S3 helpers resolve their resource at call time. These fail against the old import-time-binding code.
- Full backend suite: **337 passed** (was 334), integration suite 25 passed (local).
- The decisive verification is this PR's Backend Tests CI run, since the bug only manifests in a no-ambient-credentials environment.

Filed by snowforge-autobuild cycle 2026-06-06.