### PR TITLE
Document API-key auth in openapi spec + programmatic quickstart

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,9 +1,12 @@
 # SnowScrape -- Progress & Launch Readiness
 
-**Last Updated:** 2026-06-06
+**Last Updated:** 2026-06-07
 **Launch Readiness:** ~98% (live; Google Docs destination backend complete, awaiting Alex's Google Cloud OAuth client + deploy)
-**Build Status:** PASSES (backend full suite 337 passed green as of 2026-06-06; frontend lint + vitest 51/51 + prod build green on claude-main after the 2026-06-06 frontend CI fix)
+**Build Status:** PASSES (backend full suite 360 passed green as of 2026-06-07; frontend lint + vitest 51/51 + prod build green on claude-main after the 2026-06-06 frontend CI fix)
 **Test Coverage:** ~60-70% (unit + integration; Playwright setup present)
+
+### Recent -- 2026-06-07
+- Programmatic API: documented and spec-pinned the API-key auth that shipped on 2026-06-06 (claude/snowscrape/openapi-apikey-auth-docs, PR into claude-main). The `/jobs` data-plane accepts an `sk_live_...` API key OR a Clerk JWT (via `resolve_user_id`), but `backend/openapi.yml` still said "All endpoints require a valid Clerk JWT" and defined only the `BearerAuth` scheme, so the launch feature (sub-project #2, programmatic access) was undocumented. Changes: (1) rewrote the `info` Authentication section to describe both credential types and which surface accepts each; (2) added an `ApiKeyAuth` security scheme; (3) added `security: [BearerAuth, ApiKeyAuth]` to the 13 data-plane operations (createJob, getAllJobStatuses, getJobDetails, updateJob, deleteJob, pause/resume/cancel/refreshJob, getJobCrawls, getCrawlDetails, downloadResults, previewResults), leaving the control-plane Clerk-only by design; (4) wrote `docs/API.md`, a programmatic quickstart (create key, authenticate, job lifecycle, download, actions, rate limits); (5) added `backend/tests/unit/test_openapi_spec.py`, a drift guard that pins the spec to the real auth model (data-plane ops advertise ApiKeyAuth; control-plane ops do not), plus `pyyaml` as a dev dep. Evidence: full backend suite 360 passed / 0 failed (was 337; +23 from the new guard). No runtime code changed; frontend untouched.
 
 ### Recent -- 2026-06-06
 - Backend CI red-signal fix (claude-main, pending Alex's merge to main). The `claude-main -> main` PR (#7) `Backend Tests` job failed on `test_delete_job_handler_success` with `NoCredentialsError` (issue #16). Root cause: `utils.py` bound `s3`, `job_table` and `url_table` to connection-pool resources at module IMPORT time, pinning each resource to whatever credentials resolved during import. On CI there are no ambient AWS credentials at import (moto/test creds are set up per-test, after import), so `delete_job_links -> url_table.query` reached real boto3 with no creds. It passed locally only because the dev machine has ambient creds; the import-time binding also defeated the per-test connection-pool reset in conftest. Fix: fetch the URLs table and S3 client lazily at call time via `get_table`/`get_s3_client` (the pattern the rest of the code already uses) in `delete_job_links`, `fetch_urls_for_job`, `update_url_status`, `refresh_job_urls`, `delete_s3_result_file`; removed the dead import-time `job_table` global. Added `TestLazyAwsResourceResolution` regression tests (no import-time AWS globals; helpers resolve their resource at call time). Evidence (local): full backend suite 337 passed (was 334). Decisive verification is PR #7's Backend Tests CI re-run. Merged to claude-main via PR #19. Remaining frontend red signal on PR #7: `E2E Tests` (Playwright, issue #18).
@@ -128,7 +131,8 @@
 - Backend `api_key_handler.py` and Settings → API Keys tab fully implemented (one-time-secret modal, list/create/revoke)
 - API keys can be created and managed
 - DONE (claude-main, 2026-06-06): `Authorization: Bearer sk_live_...` now authenticates the entire `/jobs` data-plane via `resolve_user_id` (create, list, get, update, delete, pause, cancel, resume, refresh, crawls, download, preview)
-- Remaining: decide whether to extend API-key auth to the other data endpoints (templates, webhooks, export destinations); the control-plane (api-keys CRUD, billing, integrations/OAuth) stays Clerk-only by design. Public API docs / a quickstart for programmatic use would also help.
+- DONE (claude-main, 2026-06-07): public API docs + programmatic quickstart at `docs/API.md`, and `backend/openapi.yml` now documents the dual auth model (`ApiKeyAuth` scheme + `security` on the 13 data-plane ops), guarded by `test_openapi_spec.py`
+- Remaining: decide whether to extend API-key auth to the other data endpoints (templates, webhooks, export destinations); the control-plane (api-keys CRUD, billing, integrations/OAuth) stays Clerk-only by design.
 - Sub-project #2 of launch sequence
 
 ### Notification System (Partial)
@@ -149,7 +153,7 @@
 | Work Item | Estimate | Priority |
 |-----------|----------|----------|
 | First real $0 trial signup as final live smoke | hours | CRITICAL -- final acceptance |
-| API key auth on public endpoints | jobs data-plane DONE (2026-06-06); optional: extend to templates/webhooks/destinations + write API docs | MEDIUM |
+| API key auth on public endpoints | jobs data-plane DONE (2026-06-06); API docs + openapi spec DONE (2026-06-07); optional: extend to templates/webhooks/destinations | MEDIUM |
 | Real analytics data pipeline | 2-3 weeks | HIGH |
 | Email notifications | 1 week | MEDIUM |
 | In-app notification center | 1 week | LOW |

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ done
 
 ## Documentation
 
+- **[docs/API.md](./docs/API.md)** - Programmatic API quickstart (API-key auth, job lifecycle)
 - **[FEATURES.md](./FEATURES.md)** - Detailed guide to Phase 1 features (Export, Webhooks, Proxies, JS Rendering)
 - **[DEPLOYMENT.md](./DEPLOYMENT.md)** - Complete deployment guide for all features
 - **[IMPLEMENTATION_PLAN.md](./IMPLEMENTATION_PLAN.md)** - 11-phase development roadmap

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -9,8 +9,21 @@ info:
     on AWS Lambda behind API Gateway.
 
     ## Authentication
-    All endpoints (except `/health`) require a valid Clerk JWT bearer token in the
-    `Authorization` header.
+    All endpoints (except `/health`, `/validate-sftp-url`, and `/billing/webhook`) require a
+    bearer token in the `Authorization` header. Two credential types are accepted:
+
+    - **Clerk JWT** (`BearerAuth`): issued by the Clerk frontend SDK for the dashboard. Accepted
+      on every authenticated endpoint.
+    - **SnowScrape API key** (`ApiKeyAuth`): a long-lived `sk_live_...` secret created under
+      Settings -> API Keys, for programmatic access. Accepted ONLY on the `/jobs` data-plane
+      (create, list, get, update, delete, the pause/resume/cancel/refresh actions, crawls, and
+      result download/preview).
+
+    Control-plane endpoints (API key management, billing, templates, webhooks, integrations/OAuth,
+    and the scraper builder previews) remain Clerk-only by design: an API key cannot mint or revoke
+    other keys, change billing, or manage OAuth connections. Operations that accept an API key
+    advertise both schemes in their `security` block; pass either credential as
+    `Authorization: Bearer <token>`. See `docs/API.md` for a programmatic quickstart.
 
     ## Rate Limiting
     API Gateway enforces a burst limit of 200 concurrent requests and a sustained rate of
@@ -116,6 +129,9 @@ paths:
     post:
       operationId: createJob
       tags: [Jobs]
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
       summary: Create a new scraping job
       description: |
         Creates a new scraping job. Supports two source types:
@@ -157,6 +173,9 @@ paths:
     get:
       operationId: getAllJobStatuses
       tags: [Jobs]
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
       summary: List all jobs for the authenticated user
       description: |
         Returns all jobs belonging to the authenticated user with pagination support.
@@ -208,6 +227,9 @@ paths:
     get:
       operationId: getJobDetails
       tags: [Jobs]
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
       summary: Get job details
       description: Returns full details of a specific job. Verifies the authenticated user owns the job.
       parameters:
@@ -234,6 +256,9 @@ paths:
     put:
       operationId: updateJob
       tags: [Jobs]
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
       summary: Update a job
       description: Updates an existing job configuration. Validates the request body and verifies ownership.
       parameters:
@@ -268,6 +293,9 @@ paths:
     delete:
       operationId: deleteJob
       tags: [Jobs]
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
       summary: Delete a job
       description: Deletes a job and all associated crawls. Verifies ownership before deletion.
       parameters:
@@ -298,6 +326,9 @@ paths:
     patch:
       operationId: pauseJob
       tags: [Job Actions]
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
       summary: Pause a job
       description: Pauses a running or scheduled job. The job will not be picked up by the scheduler until resumed.
       parameters:
@@ -326,6 +357,9 @@ paths:
     patch:
       operationId: resumeJob
       tags: [Job Actions]
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
       summary: Resume a paused job
       description: Resumes a previously paused job so it can be picked up by the scheduler again.
       parameters:
@@ -354,6 +388,9 @@ paths:
     patch:
       operationId: cancelJob
       tags: [Job Actions]
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
       summary: Cancel a job
       description: Cancels a running or queued job. If the job is currently being processed, it will be stopped.
       parameters:
@@ -384,6 +421,9 @@ paths:
     post:
       operationId: refreshJob
       tags: [Job Actions]
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
       summary: Manually refresh / re-crawl a job
       description: |
         Triggers an immediate re-crawl for the specified job, bypassing the normal schedule.
@@ -417,6 +457,9 @@ paths:
     get:
       operationId: getJobCrawls
       tags: [Crawls]
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
       summary: List crawls for a job
       description: Returns all crawl records associated with a job. Verifies ownership of the parent job.
       parameters:
@@ -446,6 +489,9 @@ paths:
     get:
       operationId: getCrawlDetails
       tags: [Crawls]
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
       summary: Get crawl details
       description: Returns details for a specific crawl within a job. Verifies ownership of the parent job.
       parameters:
@@ -480,6 +526,9 @@ paths:
     get:
       operationId: downloadResults
       tags: [Results]
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
       summary: Download job results
       description: |
         Generates a pre-signed S3 URL for downloading job results in the requested format.
@@ -537,6 +586,9 @@ paths:
     get:
       operationId: previewResults
       tags: [Results]
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
       summary: Preview job results with pagination
       description: |
         Returns a paginated subset of job results for in-app preview. Fetches the
@@ -1372,6 +1424,16 @@ components:
       description: |
         Clerk-issued JWT token. Obtain from the Clerk frontend SDK and pass in
         the `Authorization: Bearer <token>` header.
+
+    ApiKeyAuth:
+      type: http
+      scheme: bearer
+      description: |
+        SnowScrape API key for programmatic access. Create one under
+        Settings -> API Keys; the full `sk_live_...` value is shown only once at
+        creation. Pass it in the `Authorization: Bearer sk_live_...` header.
+        Accepted ONLY on the `/jobs` data-plane (jobs CRUD, job actions, crawls,
+        and result download/preview); control-plane endpoints stay Clerk-only.
 
   # ---------------------------------------------------------------------------
   # Parameters

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
   "pytest-cov>=7.0.0",
   "pytest-env>=1.2.0",
   "moto[dynamodb,s3,sqs]>=5.0.0",
+  "pyyaml>=6.0",
 ]
 
 [build-system]

--- a/backend/tests/unit/test_openapi_spec.py
+++ b/backend/tests/unit/test_openapi_spec.py
@@ -1,0 +1,109 @@
+"""Guards that openapi.yml stays consistent with the real auth model.
+
+The canonical source of truth for "which endpoints accept a programmatic API key"
+is `resolve_user_id` in utils.py: every handler that calls it accepts either a
+Clerk JWT or an `sk_live_...` API key. Those are exactly the `/jobs` data-plane
+operations. Control-plane endpoints validate Clerk JWTs directly and must NOT
+advertise the API-key scheme. These tests pin the spec to that contract so the
+docs cannot silently drift away from the implementation again.
+"""
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+OPENAPI_PATH = Path(__file__).resolve().parents[2] / "openapi.yml"
+
+# operationIds whose handlers call resolve_user_id (the /jobs data-plane).
+# Keep in sync with the resolve_user_id call sites in handler.py.
+DATA_PLANE_OPERATIONS = {
+    "createJob",
+    "getAllJobStatuses",
+    "getJobDetails",
+    "updateJob",
+    "deleteJob",
+    "pauseJob",
+    "resumeJob",
+    "cancelJob",
+    "refreshJob",
+    "getJobCrawls",
+    "getCrawlDetails",
+    "downloadResults",
+    "previewResults",
+}
+
+# Representative control-plane operations that must stay Clerk-only.
+CLERK_ONLY_OPERATIONS = {
+    "createApiKey",
+    "listApiKeys",
+    "revokeApiKey",
+    "createTemplate",
+    "listTemplates",
+    "createWebhook",
+    "createCheckoutSession",
+    "getSubscription",
+}
+
+API_KEY_SCHEME = "ApiKeyAuth"
+CLERK_SCHEME = "BearerAuth"
+
+
+@pytest.fixture(scope="module")
+def spec():
+    with OPENAPI_PATH.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+@pytest.fixture(scope="module")
+def operations(spec):
+    """Map operationId -> the operation object across every path/method."""
+    ops = {}
+    for path_item in spec["paths"].values():
+        for method, operation in path_item.items():
+            if isinstance(operation, dict) and "operationId" in operation:
+                ops[operation["operationId"]] = operation
+    return ops
+
+
+def _schemes_for(operation):
+    """The set of security scheme names accepted by an operation."""
+    schemes = set()
+    for requirement in operation.get("security", []):
+        schemes.update(requirement.keys())
+    return schemes
+
+
+def test_spec_parses(spec):
+    assert spec["openapi"].startswith("3.")
+    assert "paths" in spec and spec["paths"]
+
+
+def test_api_key_scheme_is_defined(spec):
+    schemes = spec["components"]["securitySchemes"]
+    assert API_KEY_SCHEME in schemes, "ApiKeyAuth security scheme must be defined"
+    api_key = schemes[API_KEY_SCHEME]
+    assert api_key["type"] == "http"
+    assert api_key["scheme"] == "bearer"
+
+
+@pytest.mark.parametrize("operation_id", sorted(DATA_PLANE_OPERATIONS))
+def test_data_plane_accepts_api_key(operations, operation_id):
+    assert operation_id in operations, f"missing operation {operation_id} in spec"
+    schemes = _schemes_for(operations[operation_id])
+    assert API_KEY_SCHEME in schemes, (
+        f"{operation_id} is a /jobs data-plane op and must accept ApiKeyAuth"
+    )
+    assert CLERK_SCHEME in schemes, (
+        f"{operation_id} must still accept the Clerk JWT (BearerAuth)"
+    )
+
+
+@pytest.mark.parametrize("operation_id", sorted(CLERK_ONLY_OPERATIONS))
+def test_control_plane_rejects_api_key(operations, operation_id):
+    assert operation_id in operations, f"missing operation {operation_id} in spec"
+    schemes = _schemes_for(operations[operation_id])
+    assert API_KEY_SCHEME not in schemes, (
+        f"{operation_id} is control-plane and must stay Clerk-only (no ApiKeyAuth)"
+    )

--- a/backend/tests/unit/test_openapi_spec.py
+++ b/backend/tests/unit/test_openapi_spec.py
@@ -68,11 +68,27 @@ def operations(spec):
 
 
 def _schemes_for(operation):
-    """The set of security scheme names accepted by an operation."""
+    """The set of security scheme names declared on an operation itself."""
     schemes = set()
     for requirement in operation.get("security", []):
         schemes.update(requirement.keys())
     return schemes
+
+
+def _effective_schemes(operation, global_security):
+    """The set of accepted schemes, falling back to the global default.
+
+    OpenAPI: an operation with no `security` key inherits the document-level
+    default. Use this so the control-plane guard also catches a regression where
+    an op's entire `security` block is deleted (which would otherwise read as
+    "no auth" instead of inheriting the Clerk-only default).
+    """
+    if "security" not in operation:
+        schemes = set()
+        for requirement in global_security:
+            schemes.update(requirement.keys())
+        return schemes
+    return _schemes_for(operation)
 
 
 def test_spec_parses(spec):
@@ -101,9 +117,13 @@ def test_data_plane_accepts_api_key(operations, operation_id):
 
 
 @pytest.mark.parametrize("operation_id", sorted(CLERK_ONLY_OPERATIONS))
-def test_control_plane_rejects_api_key(operations, operation_id):
+def test_control_plane_is_clerk_only(operations, spec, operation_id):
     assert operation_id in operations, f"missing operation {operation_id} in spec"
-    schemes = _schemes_for(operations[operation_id])
-    assert API_KEY_SCHEME not in schemes, (
-        f"{operation_id} is control-plane and must stay Clerk-only (no ApiKeyAuth)"
+    schemes = _effective_schemes(operations[operation_id], spec.get("security", []))
+    # Control-plane must resolve to Clerk-only: BearerAuth present, ApiKeyAuth absent.
+    # Using effective schemes also catches a deleted security block (which would
+    # leave the op unauthenticated rather than Clerk-gated).
+    assert schemes == {CLERK_SCHEME}, (
+        f"{operation_id} is control-plane and must stay Clerk-only "
+        f"(effective schemes were {schemes or 'none'})"
     )

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,117 @@
+# SnowScrape API: Programmatic Access Quickstart
+
+SnowScrape exposes a REST API so you can create and manage scraping jobs without the
+dashboard. This guide covers authenticating with an API key and the common job
+lifecycle. The full machine-readable contract is in
+[`backend/openapi.yml`](../backend/openapi.yml).
+
+## 1. Create an API key
+
+In the dashboard, go to **Settings -> API Keys** and create a key. The full value
+(`sk_live_...`) is shown **once** at creation and stored only as a hash afterward, so
+copy it immediately. You can hold up to 10 active keys and revoke any of them from the
+same screen.
+
+API keys authenticate the entire `/jobs` data-plane: creating, listing, reading,
+updating, and deleting jobs; the pause / resume / cancel / refresh actions; reading
+crawls; and downloading or previewing results. Control-plane operations (managing API
+keys, billing, templates, webhooks, and OAuth integrations) stay dashboard-only and
+require a Clerk session, so a leaked key cannot mint new keys or change billing.
+
+## 2. Authenticate
+
+Pass the key as a bearer token on every request:
+
+```
+Authorization: Bearer sk_live_YOUR_API_KEY_HERE
+```
+
+The production base URL is the API Gateway stage URL for your environment, for example:
+
+```
+https://2pg2gj4048.execute-api.us-east-2.amazonaws.com/prod
+```
+
+A revoked or invalid key returns `401 Unauthorized`. Requesting a job you do not own
+returns `403 Forbidden`.
+
+## 3. Create a job
+
+`direct_url` jobs scrape a single URL template; `csv` jobs read a list of URLs from a
+CSV source. Minimal `direct_url` example:
+
+```bash
+curl -X POST "$BASE_URL/jobs" \
+  -H "Authorization: Bearer $SNOWSCRAPE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Daily product price",
+    "source_type": "direct_url",
+    "url_template": "https://example.com/products/{{date:Y-m-d}}",
+    "rate_limit": 2,
+    "queries": [
+      { "name": "title", "type": "xpath", "query": "//h1/text()", "join": false },
+      { "name": "price", "type": "xpath", "query": "//span[@class=\"price\"]/text()", "join": false }
+    ]
+  }'
+```
+
+Response:
+
+```json
+{ "message": "Job created successfully", "job_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }
+```
+
+## 4. List jobs and check status
+
+```bash
+curl "$BASE_URL/jobs/status?limit=50" \
+  -H "Authorization: Bearer $SNOWSCRAPE_API_KEY"
+```
+
+Paginate by passing the returned `last_key` back as the `last_key` query parameter.
+Fetch one job with `GET /jobs/{job_id}`.
+
+## 5. Trigger a run and download results
+
+Force an immediate crawl (outside the schedule), then download once it completes:
+
+```bash
+# Re-crawl now
+curl -X POST "$BASE_URL/jobs/$JOB_ID/refresh" \
+  -H "Authorization: Bearer $SNOWSCRAPE_API_KEY"
+
+# Get a pre-signed download URL (json, csv, xlsx, parquet, or sql)
+curl "$BASE_URL/jobs/$JOB_ID/download?format=csv" \
+  -H "Authorization: Bearer $SNOWSCRAPE_API_KEY"
+```
+
+`download` returns a short-lived pre-signed S3 URL in `download_url`. For an in-app style
+paginated view of the rows, use `GET /jobs/{job_id}/preview?page=1&page_size=50`.
+
+## 6. Job actions
+
+| Action  | Request                                  |
+|---------|------------------------------------------|
+| Pause   | `PATCH /jobs/{job_id}/pause`             |
+| Resume  | `PATCH /jobs/{job_id}/resume`            |
+| Cancel  | `PATCH /jobs/{job_id}/cancel`            |
+| Refresh | `POST  /jobs/{job_id}/refresh`           |
+| Update  | `PUT   /jobs/{job_id}` (same body as create) |
+| Delete  | `DELETE /jobs/{job_id}`                  |
+
+## Rate limits
+
+API Gateway enforces a burst limit of 200 concurrent requests and a sustained 100
+requests/second across the account. Per-plan page quotas apply to the scraping work
+itself and are enforced at job-create time; a `402` means the subscription is inactive
+or the quota is exhausted.
+
+## Notes
+
+- All authenticated requests use the same `Authorization: Bearer ...` header whether the
+  token is a Clerk session JWT (dashboard) or an `sk_live_...` API key (programmatic).
+- Webhooks (job lifecycle events) are configured in the dashboard. They are part of the
+  control-plane, so they cannot be managed with an API key today.
+- The `/jobs` data-plane is the supported programmatic surface. Templates and export
+  destinations are dashboard-managed for now.

--- a/uv.lock
+++ b/uv.lock
@@ -120,6 +120,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-mock" },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -165,6 +166,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-env", specifier = ">=1.2.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

The `/jobs` data-plane accepts an `sk_live_` API key OR a Clerk JWT (via `resolve_user_id`), but `backend/openapi.yml` still said *all endpoints require a Clerk JWT* and defined only `BearerAuth`. The programmatic-access launch feature (sub-project #2) shipped on 2026-06-06 was therefore undocumented.

## Changes
- Rewrote the `info` Authentication section: two credential types and which surface accepts each.
- Added an `ApiKeyAuth` security scheme; declared it (with `BearerAuth`) on the 13 `/jobs` data-plane operations. Control-plane stays Clerk-only by design.
- Added `docs/API.md`, a programmatic quickstart (key creation, auth, job lifecycle, download, actions, rate limits); linked from README.
- Added `backend/tests/unit/test_openapi_spec.py`, a drift guard pinning the spec to the real auth model; added `pyyaml` dev dep.

## Tests
Full backend suite: **360 passed / 0 failed** (was 337; +23 from the new guard). No runtime code changed; frontend untouched.

Filed by snowforge-autobuild cycle 2026-06-07.