### PR TITLE
Fix Visual builder job creation: send direct_url source_type (#8)

### DIFF
--- a/frontend/app/(application)/dashboard/jobs/new/visual/page.tsx
+++ b/frontend/app/(application)/dashboard/jobs/new/visual/page.tsx
@@ -37,6 +37,7 @@ import { toast } from '@/lib/toast';
 import { jobsAPI } from '@/lib/api';
 import { DestinationSelector } from '@/components/destinations/DestinationSelector';
 import { useWebSocket } from '@/lib/useWebSocket';
+import { buildVisualJobPayload } from '@/lib/jobs/buildVisualJobPayload';
 
 interface ExtractedField {
   id: string;
@@ -362,23 +363,17 @@ export default function VisualBuilderPage() {
         return;
       }
 
-      // Format queries from extracted fields
-      const queries = extractedFields.map((field) => ({
-        name: field.name,
-        type: field.type,
-        query: field.selector,
-        join: false,
-      }));
-
-      // Create the job
+      // The Visual builder scrapes a single target URL, so it must create a
+      // direct_url job. Without source_type the backend defaults to 'csv' and
+      // then requires a file_mapping this flow never sends, rejecting the job.
       const job = await jobsAPI.create(
-        {
+        buildVisualJobPayload({
           name: jobName.trim(),
-          source: targetUrl,
-          queries,
-          rate_limit: 10, // Default rate limit
-          export_destination_ids: destinationIds,
-        },
+          url: targetUrl,
+          rateLimit: 10, // Default rate limit
+          fields: extractedFields,
+          destinationIds,
+        }),
         token
       );
 

--- a/frontend/lib/__tests__/buildVisualJobPayload.test.ts
+++ b/frontend/lib/__tests__/buildVisualJobPayload.test.ts
@@ -69,7 +69,7 @@ describe('buildVisualJobPayload', () => {
     expect(payload.export_destination_ids).toEqual(['d-1', 'd-2']);
   });
 
-  it('defaults export_destination_ids to an empty array', () => {
+  it('passes an empty export_destination_ids array through unchanged', () => {
     const payload = buildVisualJobPayload({
       name: 'Test',
       url: 'https://example.com',

--- a/frontend/lib/__tests__/buildVisualJobPayload.test.ts
+++ b/frontend/lib/__tests__/buildVisualJobPayload.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildVisualJobPayload,
+  type VisualExtractedField,
+} from '@/lib/jobs/buildVisualJobPayload';
+
+const field = (over: Partial<VisualExtractedField> = {}): VisualExtractedField => ({
+  name: 'price',
+  selector: '//span[@class="price"]',
+  type: 'xpath',
+  ...over,
+});
+
+describe('buildVisualJobPayload', () => {
+  it('creates a direct_url job (source_type + url_template) so backend validation passes', () => {
+    const payload = buildVisualJobPayload({
+      name: 'My Job',
+      url: 'https://example.com/products',
+      rateLimit: 10,
+      fields: [field()],
+      destinationIds: [],
+    });
+
+    expect(payload.name).toBe('My Job');
+    expect(payload.source).toBe('https://example.com/products');
+    expect(payload.source_type).toBe('direct_url');
+    expect(payload.url_template).toBe('https://example.com/products');
+    expect(payload.rate_limit).toBe(10);
+  });
+
+  it('maps each extracted field to a query (name, type, selector as query)', () => {
+    const payload = buildVisualJobPayload({
+      name: 'Test',
+      url: 'https://example.com',
+      rateLimit: 10,
+      fields: [
+        field({ name: 'price', selector: '//p', type: 'xpath' }),
+        field({ name: 'title', selector: 'h1.title', type: 'regex' }),
+      ],
+      destinationIds: [],
+    });
+
+    expect(payload.queries).toHaveLength(2);
+    expect(payload.queries[0]).toMatchObject({ name: 'price', type: 'xpath', query: '//p', join: false });
+    expect(payload.queries[1]).toMatchObject({ name: 'title', type: 'regex', query: 'h1.title', join: false });
+  });
+
+  it('downgrades css selectors to xpath (backend job runner does not support raw css)', () => {
+    const payload = buildVisualJobPayload({
+      name: 'Test',
+      url: 'https://example.com',
+      rateLimit: 10,
+      fields: [field({ type: 'css' })],
+      destinationIds: [],
+    });
+
+    expect(payload.queries[0].type).toBe('xpath');
+  });
+
+  it('passes export_destination_ids through to the payload', () => {
+    const payload = buildVisualJobPayload({
+      name: 'Test',
+      url: 'https://example.com',
+      rateLimit: 10,
+      fields: [field()],
+      destinationIds: ['d-1', 'd-2'],
+    });
+
+    expect(payload.export_destination_ids).toEqual(['d-1', 'd-2']);
+  });
+
+  it('defaults export_destination_ids to an empty array', () => {
+    const payload = buildVisualJobPayload({
+      name: 'Test',
+      url: 'https://example.com',
+      rateLimit: 10,
+      fields: [field()],
+      destinationIds: [],
+    });
+
+    expect(payload.export_destination_ids).toEqual([]);
+  });
+});

--- a/frontend/lib/jobs/buildVisualJobPayload.ts
+++ b/frontend/lib/jobs/buildVisualJobPayload.ts
@@ -1,0 +1,54 @@
+/**
+ * buildVisualJobPayload
+ * Pure helper that turns the Visual Scraper Builder's extracted fields into a
+ * CreateJobDTO. Extracted (mirroring buildAiJobPayload) so the payload shape is
+ * unit-testable independently of the React page.
+ *
+ * The Visual builder scrapes a single target URL, so it must create a
+ * `direct_url` job (source_type + url_template). Without source_type the backend
+ * defaults to 'csv' and then requires a file_mapping the Visual builder never
+ * sends, so job creation was rejected outright.
+ */
+
+import type { CreateJobDTO } from '@/lib/api/jobs';
+
+export interface VisualExtractedField {
+  name: string;
+  selector: string;
+  type: 'xpath' | 'css' | 'regex';
+}
+
+interface BuildVisualJobPayloadParams {
+  name: string;
+  url: string;
+  rateLimit: number;
+  fields: VisualExtractedField[];
+  destinationIds: string[];
+}
+
+export function buildVisualJobPayload({
+  name,
+  url,
+  rateLimit,
+  fields,
+  destinationIds,
+}: BuildVisualJobPayloadParams): CreateJobDTO {
+  const queries = fields.map((field) => ({
+    name: field.name,
+    // The backend job runner supports xpath/regex (not raw css), so a css
+    // selector is downgraded to xpath, matching the AI flow (buildAiJobPayload).
+    type: field.type === 'css' ? 'xpath' : field.type,
+    query: field.selector,
+    join: false,
+  }));
+
+  return {
+    name,
+    source: url,
+    source_type: 'direct_url',
+    url_template: url,
+    rate_limit: rateLimit,
+    queries,
+    export_destination_ids: destinationIds,
+  };
+}


### PR DESCRIPTION
## What

Fixes #8. The Visual Scraper Builder's **Create Job** sent a payload with no `source_type` and no `url_template`. The backend defaults `source_type` to `'csv'` (`backend/validators.py`), which then **requires a `file_mapping`** the Visual builder never sends, so the builder's primary action always failed validation.

## Change

- New pure helper `frontend/lib/jobs/buildVisualJobPayload.ts` (mirrors the existing `buildAiJobPayload`): builds a `direct_url` `CreateJobDTO` with `url_template` set to the target URL, so single-URL scrapes validate.
- Downgrades `css` field types to `xpath` (the backend job runner accepts `xpath/regex/jsonpath/pdf_*`, not raw `css`), matching the AI flow.
- Wires the helper into `visual/page.tsx` `handleSaveAsJob`, replacing the inline payload.
- 5 unit tests for the payload shape.

## Verification

- `pnpm vitest run`: **56 passed** (51 prior + 5 new), 0 failed.
- `pnpm lint`: 0 errors, 106 warnings (unchanged pre-existing baseline).
- `doppler --config dev -- pnpm build`: **Compiled successfully**, 27/27 static pages, exit 0.
- Independent adversarial diff review: APPROVE, no HIGH; one MEDIUM (misleading test name) addressed.

## Known follow-up (not in scope)

The css->xpath downgrade fixes validation but leaves a css-syntax `query` string labeled `xpath`, so a manually-added css field can extract nothing at runtime (same latent behavior as the AI helper). Auto-extracted fields are already `xpath`, so this is rare; tracked as a separate issue.

Filed by snowforge-autobuild cycle 2026-06-07.