### PR TITLE
Enforce the 10-destination cap client-side in DestinationSelector (#9)

### DIFF
--- a/frontend/components/destinations/DestinationSelector.test.tsx
+++ b/frontend/components/destinations/DestinationSelector.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * DestinationSelector Component Test
+ * Pins the client-side 10-destination cap (mirrors backend/utils.py) and the
+ * count indicator, so a user discovers the limit before submitting (issue #9).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@/lib/test-utils';
+import userEvent from '@testing-library/user-event';
+import { DestinationSelector } from '@/components/destinations/DestinationSelector';
+import type { ExportDestination } from '@/lib/api/destinations';
+
+// Drive the component via a mutable hook return so each test controls the list.
+let hookState: { data: ExportDestination[] | undefined; isLoading: boolean };
+
+vi.mock('@/lib/hooks/useDestinations', () => ({
+  useDestinations: () => hookState,
+}));
+
+function makeDestination(i: number): ExportDestination {
+  return {
+    destination_id: `dest-${i}`,
+    user_id: 'user-1',
+    name: `Destination ${i}`,
+    type: 'google_docs',
+    drive_folder_id: `folder-${i}`,
+    naming_template: 'Run {date}',
+    mode: 'new_doc_per_run',
+    format_template: 'structured_log',
+    google_user_id: 'g-1',
+    created_at: '2026-06-08T00:00:00Z',
+  };
+}
+
+function makeDestinations(n: number): ExportDestination[] {
+  return Array.from({ length: n }, (_, i) => makeDestination(i));
+}
+
+beforeEach(() => {
+  hookState = { data: makeDestinations(12), isLoading: false };
+});
+
+describe('DestinationSelector cap', () => {
+  it('shows the selected count out of the max', () => {
+    render(<DestinationSelector value={['dest-0', 'dest-1']} onChange={() => {}} />);
+    expect(screen.getByText('2 / 10 selected')).toBeInTheDocument();
+  });
+
+  it('leaves unchecked boxes enabled and adds an id below the cap', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<DestinationSelector value={['dest-0']} onChange={onChange} />);
+
+    const boxes = screen.getAllByRole('checkbox');
+    expect(boxes[1]).not.toBeDisabled();
+
+    await user.click(boxes[1]);
+    expect(onChange).toHaveBeenCalledWith(['dest-0', 'dest-1']);
+  });
+
+  it('disables unchecked boxes and shows the cap message at the limit', () => {
+    const selected = Array.from({ length: 10 }, (_, i) => `dest-${i}`);
+    render(<DestinationSelector value={selected} onChange={() => {}} />);
+
+    expect(screen.getByText('10 / 10 selected')).toBeInTheDocument();
+    expect(screen.getByText('Maximum 10 destinations per job')).toBeInTheDocument();
+
+    const boxes = screen.getAllByRole('checkbox');
+    // The 11th destination (dest-10) is unchecked -> disabled at the cap.
+    expect(boxes[10]).toBeDisabled();
+    // An already-selected destination stays enabled so it can be unchecked.
+    expect(boxes[0]).not.toBeDisabled();
+  });
+
+  it('does not add a new id when at the cap even if toggle fires', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    const selected = Array.from({ length: 10 }, (_, i) => `dest-${i}`);
+    render(<DestinationSelector value={selected} onChange={onChange} />);
+
+    const boxes = screen.getAllByRole('checkbox');
+    await user.click(boxes[10]); // disabled, must not fire
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('still allows unchecking a selected destination at the cap', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    const selected = Array.from({ length: 10 }, (_, i) => `dest-${i}`);
+    render(<DestinationSelector value={selected} onChange={onChange} />);
+
+    const boxes = screen.getAllByRole('checkbox');
+    await user.click(boxes[0]);
+    expect(onChange).toHaveBeenCalledWith(selected.filter((id) => id !== 'dest-0'));
+  });
+});

--- a/frontend/components/destinations/DestinationSelector.tsx
+++ b/frontend/components/destinations/DestinationSelector.tsx
@@ -59,7 +59,11 @@ export function DestinationSelector({ value, onChange }: Props) {
         <span>
           {value.length} / {MAX_DESTINATIONS} selected
         </span>
-        {atCap && <span>Maximum {MAX_DESTINATIONS} destinations per job</span>}
+        {atCap && (
+          <span role="status" aria-live="polite">
+            Maximum {MAX_DESTINATIONS} destinations per job
+          </span>
+        )}
       </div>
       {destinations.map((d) => {
         const isChecked = value.includes(d.destination_id);

--- a/frontend/components/destinations/DestinationSelector.tsx
+++ b/frontend/components/destinations/DestinationSelector.tsx
@@ -15,11 +15,22 @@ interface Props {
   onChange: (ids: string[]) => void;
 }
 
+// Mirrors the backend cap in backend/utils.py ("Maximum 10 export destinations per job").
+// Keep in sync if the server limit changes.
+const MAX_DESTINATIONS = 10;
+
 export function DestinationSelector({ value, onChange }: Props) {
   const { data: destinations, isLoading } = useDestinations();
+  const atCap = value.length >= MAX_DESTINATIONS;
 
   function toggle(id: string, checked: boolean) {
-    onChange(checked ? [...value, id] : value.filter((x) => x !== id));
+    if (checked) {
+      // Guard the cap even if a disabled control is somehow toggled.
+      if (value.includes(id) || value.length >= MAX_DESTINATIONS) return;
+      onChange([...value, id]);
+    } else {
+      onChange(value.filter((x) => x !== id));
+    }
   }
 
   if (isLoading) {
@@ -44,15 +55,29 @@ export function DestinationSelector({ value, onChange }: Props) {
 
   return (
     <div className="space-y-2">
-      {destinations.map((d) => (
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>
+          {value.length} / {MAX_DESTINATIONS} selected
+        </span>
+        {atCap && <span>Maximum {MAX_DESTINATIONS} destinations per job</span>}
+      </div>
+      {destinations.map((d) => {
+        const isChecked = value.includes(d.destination_id);
+        const isDisabled = atCap && !isChecked;
+        return (
         <label
           key={d.destination_id}
-          className="flex items-center gap-3 rounded-md border p-3 hover:bg-muted/50 cursor-pointer"
+          className={`flex items-center gap-3 rounded-md border p-3 ${
+            isDisabled
+              ? 'cursor-not-allowed opacity-50'
+              : 'hover:bg-muted/50 cursor-pointer'
+          }`}
           htmlFor={`dest-${d.destination_id}`}
         >
           <Checkbox
             id={`dest-${d.destination_id}`}
-            checked={value.includes(d.destination_id)}
+            checked={isChecked}
+            disabled={isDisabled}
             onCheckedChange={(c) => toggle(d.destination_id, Boolean(c))}
           />
           <div className="flex-1">
@@ -67,7 +92,8 @@ export function DestinationSelector({ value, onChange }: Props) {
             </div>
           </div>
         </label>
-      ))}
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
Closes #9 on merge to main.

## What
The backend caps a job at 10 export destinations (`backend/utils.py`: `Maximum 10 export destinations per job`). `DestinationSelector` previously let users check unlimited boxes, so the cap was only discovered when the create request failed with a 422.

## Change (frontend-only, no runtime/backend change)
- Add `MAX_DESTINATIONS = 10` (mirrors the backend; commented to keep in sync).
- Disable unchecked checkboxes once 10 are selected (`cursor-not-allowed opacity-50`); already-selected boxes stay enabled so they can still be unchecked.
- Guard `toggle()` so it never adds beyond the cap even if a disabled control is somehow toggled.
- Show an `N / 10 selected` count and a `Maximum 10 destinations per job` message at the cap.
- Benefits the manual, AI, and Visual job-creation flows that share this selector.

## Tests / evidence
- New `DestinationSelector.test.tsx` (+5): count indicator, enabled+add below cap, disabled unchecked + cap message at limit, no-add-when-at-cap, still-uncheck-at-cap.
- Frontend vitest: 118 passed (was 113).
- `eslint .`: 0 errors / 106 baseline warnings.
- `doppler --config dev -- pnpm build`: exit 0, Compiled successfully.

Filed by snowforge-autobuild cycle 2026-06-08.