### PR TITLE
E2E: inject real Clerk keys via Doppler

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -113,15 +113,17 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps
 
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
       - name: Run E2E tests
-        run: pnpm test:e2e
+        # Inject the real sf-snowscrape/dev env (incl. the Clerk keys the dev server needs to
+        # boot) via a read-only Doppler service token. ClerkProvider throws without a real
+        # publishableKey, and a placeholder key resolves to a non-existent frontend API host.
+        run: doppler run -- pnpm test:e2e
         env:
           CI: true
-          # Placeholder Clerk keys so the dev server boots in CI (ClerkProvider throws on a
-          # missing publishableKey). E2E covers public pages, not real authenticated flows.
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_Y2xlcmsuZXhhbXBsZS5jb20k
-          CLERK_SECRET_KEY: sk_test_ci_placeholder_not_a_real_secret
-          NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL || 'https://api.snowscrape.com' }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Wires the SnowScrape E2E job to the real `sf-snowscrape/dev` env via a read-only Doppler service token (`DOPPLER_TOKEN` repo secret) instead of placeholder Clerk keys. The dev server needs a real Clerk publishableKey to boot and load the client script; the placeholder pointed at a non-existent frontend API host. Follows the Doppler-is-source-of-truth convention used across SnowForge.